### PR TITLE
Chore: "Add react-icons"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
         "@reduxjs/toolkit": "^1.9.5",
         "dotenv": "^16.3.1",
         "git-flow": "^0.2.0",
-        "gitflow": "^0.5.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.11.0",
         "react-redux": "^8.1.2",
         "react-router-dom": "^6.15.0",
         "redux-promise": "^0.6.0",
@@ -2132,11 +2132,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
-    },
     "node_modules/babel-polyfill": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
@@ -2175,14 +2170,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/binary-search-tree": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/binary-search-tree/-/binary-search-tree-0.2.5.tgz",
-      "integrity": "sha512-CvNVKS6iXagL1uGwLagSXz1hzSMezxOuGnFi5FHGKqaTO3nPPWrAbyALUzK640j+xOTVm7lzD9YP8W1f/gvUdw==",
-      "dependencies": {
-        "underscore": "~1.4.4"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -2202,18 +2189,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/breakout-timeline": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/breakout-timeline/-/breakout-timeline-0.0.4.tgz",
-      "integrity": "sha512-I3Pkn78L28Ry5ejh4uCb6eED83AnR+hQ9LcGL3s4WV8saPmQKqikdFqrV8WKzzl9XenrJEYjDyXER7YdyDGjsQ==",
-      "dependencies": {
-        "home-dir": "^1.0.0",
-        "nedb": "^1.8.0"
-      },
-      "bin": {
-        "breakout-timeline": "bin/index.js"
       }
     },
     "node_modules/browserslist": {
@@ -2444,11 +2419,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/commitizen": {
       "version": "2.10.1",
@@ -4207,23 +4177,6 @@
         "ini": "^1.3.2"
       }
     },
-    "node_modules/gitflow": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/gitflow/-/gitflow-0.5.5.tgz",
-      "integrity": "sha512-4ufkPtXhQ7H7GlWSQXY420ZgDPD/n5wQnJefOxV0wzXRjQr0ySyXM+s+fiq5i7O7i5wIz2UwNj2GoTc1mQJ5NQ==",
-      "hasInstallScript": true,
-      "os": [
-        "!win32"
-      ],
-      "dependencies": {
-        "breakout-timeline": "0.0.4",
-        "commander": "^2.9.0",
-        "shelljs": "^0.7.6"
-      },
-      "bin": {
-        "breakout-flow": "node_modules/breakout-timeline/bin/index.js"
-      }
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -4451,11 +4404,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
-    "node_modules/home-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/home-dir/-/home-dir-1.0.0.tgz",
-      "integrity": "sha512-PPAP0BMY72XQ0sYwFow8EgHwUYfptkZusnZEGHkBjdKRXIYcVFsbEViqU4k8VrJWf0m7wMr9gscQX9klJYh7zg=="
-    },
     "node_modules/homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -4503,11 +4451,6 @@
       "engines": {
         "node": ">= 4"
       }
-    },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "node_modules/immer": {
       "version": "9.0.21",
@@ -5012,14 +4955,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
     "node_modules/load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -5033,14 +4968,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/localforage": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-      "dependencies": {
-        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -5384,25 +5311,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mkdirp/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -5445,18 +5353,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "node_modules/nedb": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/nedb/-/nedb-1.8.0.tgz",
-      "integrity": "sha512-ip7BJdyb5m+86ZbSb4y10FCCW9g35+U8bDRrZlAfCI6m4dKwEsQ5M52grcDcVK4Vm/vnPlDLywkyo3GliEkb5A==",
-      "dependencies": {
-        "async": "0.2.10",
-        "binary-search-tree": "0.2.5",
-        "localforage": "^1.3.0",
-        "mkdirp": "~0.5.1",
-        "underscore": "~1.4.4"
-      }
     },
     "node_modules/neo-async": {
       "version": "2.6.2",
@@ -6202,6 +6098,14 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {
@@ -7070,11 +6974,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha512-ZqGrAgaqqZM7LGRzNjLnw5elevWb5M8LEoDMadxIW3OWbcv72wMMgKdwOKpd5Fqxe8choLD8HN3iSj3TUh/giQ=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.11",
@@ -8893,11 +8792,6 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA=="
     },
-    "async": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ=="
-    },
     "babel-polyfill": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
@@ -8935,14 +8829,6 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
-    "binary-search-tree": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/binary-search-tree/-/binary-search-tree-0.2.5.tgz",
-      "integrity": "sha512-CvNVKS6iXagL1uGwLagSXz1hzSMezxOuGnFi5FHGKqaTO3nPPWrAbyALUzK640j+xOTVm7lzD9YP8W1f/gvUdw==",
-      "requires": {
-        "underscore": "~1.4.4"
-      }
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -8959,15 +8845,6 @@
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
-      }
-    },
-    "breakout-timeline": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/breakout-timeline/-/breakout-timeline-0.0.4.tgz",
-      "integrity": "sha512-I3Pkn78L28Ry5ejh4uCb6eED83AnR+hQ9LcGL3s4WV8saPmQKqikdFqrV8WKzzl9XenrJEYjDyXER7YdyDGjsQ==",
-      "requires": {
-        "home-dir": "^1.0.0",
-        "nedb": "^1.8.0"
       }
     },
     "browserslist": {
@@ -9127,11 +9004,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "commitizen": {
       "version": "2.10.1",
@@ -10516,16 +10388,6 @@
         "ini": "^1.3.2"
       }
     },
-    "gitflow": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/gitflow/-/gitflow-0.5.5.tgz",
-      "integrity": "sha512-4ufkPtXhQ7H7GlWSQXY420ZgDPD/n5wQnJefOxV0wzXRjQr0ySyXM+s+fiq5i7O7i5wIz2UwNj2GoTc1mQJ5NQ==",
-      "requires": {
-        "breakout-timeline": "0.0.4",
-        "commander": "^2.9.0",
-        "shelljs": "^0.7.6"
-      }
-    },
     "glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -10704,11 +10566,6 @@
         }
       }
     },
-    "home-dir": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/home-dir/-/home-dir-1.0.0.tgz",
-      "integrity": "sha512-PPAP0BMY72XQ0sYwFow8EgHwUYfptkZusnZEGHkBjdKRXIYcVFsbEViqU4k8VrJWf0m7wMr9gscQX9klJYh7zg=="
-    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -10747,11 +10604,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
       "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true
-    },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "immer": {
       "version": "9.0.21",
@@ -11134,14 +10986,6 @@
         "type-check": "~0.4.0"
       }
     },
-    "lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-      "requires": {
-        "immediate": "~3.0.5"
-      }
-    },
     "load-json-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -11152,14 +10996,6 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0",
         "strip-bom": "^2.0.0"
-      }
-    },
-    "localforage": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-      "requires": {
-        "lie": "3.1.1"
       }
     },
     "locate-path": {
@@ -11433,21 +11269,6 @@
         "is-plain-obj": "^1.1.0"
       }
     },
-    "mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "requires": {
-        "minimist": "^1.2.6"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-          "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
-        }
-      }
-    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -11475,18 +11296,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
-    },
-    "nedb": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/nedb/-/nedb-1.8.0.tgz",
-      "integrity": "sha512-ip7BJdyb5m+86ZbSb4y10FCCW9g35+U8bDRrZlAfCI6m4dKwEsQ5M52grcDcVK4Vm/vnPlDLywkyo3GliEkb5A==",
-      "requires": {
-        "async": "0.2.10",
-        "binary-search-tree": "0.2.5",
-        "localforage": "^1.3.0",
-        "mkdirp": "~0.5.1",
-        "underscore": "~1.4.4"
-      }
     },
     "neo-async": {
       "version": "2.6.2",
@@ -12020,6 +11829,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-icons": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "requires": {}
     },
     "react-is": {
       "version": "18.2.0",
@@ -12642,11 +12457,6 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
       "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
       "optional": true
-    },
-    "underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha512-ZqGrAgaqqZM7LGRzNjLnw5elevWb5M8LEoDMadxIW3OWbcv72wMMgKdwOKpd5Fqxe8choLD8HN3iSj3TUh/giQ=="
     },
     "update-browserslist-db": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gitflow": "^0.5.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.11.0",
     "react-redux": "^8.1.2",
     "react-router-dom": "^6.15.0",
     "redux-promise": "^0.6.0",

--- a/src/views/LoginPage.tsx
+++ b/src/views/LoginPage.tsx
@@ -1,5 +1,12 @@
 import React from 'react';
+import { BsFillXCircleFill, BsCheckCircleFill } from 'react-icons/bs';
 
 export const LoginPage = () => {
-  return <div>LoginPage </div>;
+  return (
+    <div>
+      LoginPage
+      <BsFillXCircleFill />
+      <BsCheckCircleFill />
+    </div>
+  );
 };


### PR DESCRIPTION
리액트에서 아이콘을 쉽게 사용할 수 있는 npm package를 추가하였습니다.

https://react-icons.github.io/react-icons 

아이콘을 사용하고자 하는 컴포넌트 상단에 import 해와서 컴포넌트처럼 사용하시면 됩니다.
```jsx
import { BsFillXCircleFill, BsCheckCircleFill } from 'react-icons/bs';

export const LoginPage = () => {
  return (
    <div>
      <BsFillXCircleFill />
      <BsCheckCircleFill />
    </div>
  );
};
```

+추가)
import from 부분의 /bs 부분은 선택한 아이콘의 종류입니다. 사이트에서 아이콘을 고르실 때 이름에 bs bi 등이 적혀져있습니다.


